### PR TITLE
修复: 搜索框输入空格时触发播放暂停问题

### DIFF
--- a/lib/components/window_ctrl_bar.dart
+++ b/lib/components/window_ctrl_bar.dart
@@ -7,6 +7,7 @@ import 'package:zerobit_player/theme_manager.dart';
 import '../desktop_lyrics_sever.dart';
 import '../field/tag_suffix.dart';
 import '../getxController/audio_ctrl.dart';
+import '../getxController/focus_manager_ctrl.dart';
 import '../getxController/music_cache_ctrl.dart';
 import '../tools/general_style.dart';
 import '../getxController/setting_ctrl.dart';
@@ -17,6 +18,7 @@ final ThemeService _themeService = Get.find<ThemeService>();
 final MusicCacheController _musicCacheController =
     Get.find<MusicCacheController>();
 final AudioController _audioController = Get.find<AudioController>();
+final FocusManagerController _focusManager = Get.put(FocusManagerController());
 
 final DesktopLyricsSever _desktopLyricsSever = Get.find<DesktopLyricsSever>();
 
@@ -143,6 +145,13 @@ class _SearchDialog extends StatelessWidget {
         _musicCacheController.searchResult.clear();
         _musicCacheController.searchText.value = '';
         final searchCtrl = TextEditingController();
+        final searchFocusNode = FocusNode();
+
+        searchFocusNode.addListener(() {
+          _focusManager.setTextFieldFocus(searchFocusNode.hasFocus);
+        });
+        _focusManager.setTextFieldFocus(true);
+
         showDialog(
           barrierDismissible: true,
           context: context,
@@ -172,6 +181,7 @@ class _SearchDialog extends StatelessWidget {
                       TextField(
                         autofocus: true,
                         controller: searchCtrl,
+                        focusNode: searchFocusNode,
                         decoration: InputDecoration(
                           border: OutlineInputBorder(),
                           labelText: '搜索',

--- a/lib/getxController/focus_manager_ctrl.dart
+++ b/lib/getxController/focus_manager_ctrl.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+
+class FocusManagerController extends GetxController {
+  final isTextFieldFocused = false.obs;
+
+  void setTextFieldFocus(bool hasFocus) {
+    isTextFieldFocused.value = hasFocus;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -317,6 +317,9 @@ void main() async {
 
   try {
     _smtcSub = smtcControlEvents().listen((event) {
+      if (focusManager.isTextFieldFocused.value) {
+        return;
+      }
       switch (event) {
         case SMTCControlEvent.play:
           audioController.audioResume.throttle(ms: 300)();


### PR DESCRIPTION
新增 FocusManagerController 管理文本输入焦点状态
当搜索对话框打开时，忽略 SMTC 事件以允许正常输入空格字符
关闭对话框后恢复空格键的播放暂停功能

关联 Issue: https://github.com/Empty-57/ZeroBit-Player/issues/24