### PR TITLE
feat: 播放页支持 ESC 键退出

### DIFF
--- a/lib/pages/lrc_view.dart
+++ b/lib/pages/lrc_view.dart
@@ -1178,7 +1178,10 @@ class LrcView extends StatelessWidget {
       ),
     ];
 
-    return BlurWithCoverBackground(
+    return Focus(
+      autofocus: true,
+      onKeyEvent: _onKeyEvent,
+      child: BlurWithCoverBackground(
       cover: _audioController.currentCover,
       useGradient: false,
       sigma: 256,
@@ -1396,6 +1399,7 @@ class LrcView extends StatelessWidget {
             ),
           ],
         ),
+      ),
       ),
     );
   }

--- a/lib/pages/lrc_view.dart
+++ b/lib/pages/lrc_view.dart
@@ -1011,6 +1011,15 @@ class LrcView extends StatelessWidget {
     );
   }
 
+  KeyEventResult _onKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is KeyDownEvent &&
+        event.logicalKey == LogicalKeyboardKey.escape) {
+      Get.back();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
   @override
   Widget build(BuildContext context) {
     double coverSize = (context.width * 0.3).clamp(300, 500);

--- a/lib/pages/lrc_view.dart
+++ b/lib/pages/lrc_view.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:get/get.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';


### PR DESCRIPTION
## 改动
在播放页添加 ESC 键退出功能，按 ESC 键可从播放页返回主页面。

## 实现
- 用 `Focus` 组件包裹播放页内容，自动获取焦点
- 监听 `KeyDownEvent`，检测到 ESC 键时调用 `Get.back()` 返回
- 对话框打开时优先关闭对话框，不影响原有交互逻辑